### PR TITLE
Fix B*Q*B' input guard in covariance prediction + regression tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,20 @@ jobs:
       - name: Build
         run: cmake --build build
 
-      - name: Run example
-        run: ./build/example
+      - name: Run tests (Debug)
+        run: ctest --test-dir build --output-on-failure
+
+      # Re-run the suite optimized but with assertions still enabled (Debug type so
+      # NDEBUG is not defined). This exercises the in-place matrix_sub aliasing path
+      # under -O2, where a stray `restrict` could otherwise miscompile.
+      - name: Configure (optimized, assertions on)
+        run: cmake -B build-opt -S . -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_FLAGS="-O2"
+
+      - name: Build (optimized)
+        run: cmake --build build-opt
+
+      - name: Run tests (optimized)
+        run: ctest --test-dir build-opt --output-on-failure
 
       - name: Configure (library only, examples OFF)
         run: cmake -B build-lib-only -S . -DKALMAN_CLIB_BUILD_EXAMPLES=OFF

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ if(KALMAN_CLIB_BUILD_EXAMPLES)
     add_executable(example
             src/kalman_example.c
             src/kalman_example_gravity.c
+            src/kalman_unittests.c
             src/main.c
             src/matrix_unittests.c)
     target_include_directories(example PRIVATE include src)
@@ -49,6 +50,10 @@ if(KALMAN_CLIB_BUILD_EXAMPLES)
             SPDX_LICENSE_IDENTIFIER "MIT"
             SPDX_COPYRIGHT_TEXT     "Copyright (c) 2014-2024 Markus Mayer"
             PROJECT_URL             "https://github.com/sunsided/kalman-clib")
+
+    # The example binary doubles as the test suite (asserts must stay enabled).
+    enable_testing()
+    add_test(NAME kalman_clib_tests COMMAND example)
 endif()
 
 # ── Install ──────────────────────────────────────────────────────────────────

--- a/include/kalman.h
+++ b/include/kalman.h
@@ -264,7 +264,6 @@ void kalman_predict_Q_tuned(register kalman_t *const kf, matrix_data_t lambda) H
 /*!
 * \brief Performs the time update / prediction step.
 * \param[in] kf The Kalman Filter structure to predict with.
-* \param[in] lambda Lambda factor (\c 0 < {\ref lambda} <= \c 1) to forcibly reduce prediction certainty. Smaller values mean larger uncertainty.
 *
 * This call assumes that the input covariance and variables are already set in the filter structure.
 *

--- a/include/matrix.h
+++ b/include/matrix.h
@@ -247,13 +247,16 @@ EXTERN_INLINE_MATRIX void matrix_copy(const matrix_t *const mat, matrix_t *const
 * \param[in] a The matrix to subtract from
 * \param[in] b The values to subtract
 * \param[in] c The output
+*
+* The output {\ref c} may alias the input {\ref a} (in-place subtraction), as done
+* in kalman_correct's P = P - K*H*P. Hence {\ref a} must not be {\c restrict}-qualified.
 */
 HOT EXTERN_INLINE_MATRIX void matrix_sub(const matrix_t *const a, matrix_t *const b, const matrix_t *c)
 {
     register const uint_fast16_t count = a->cols * a->rows;
     register int_fast16_t index = 0;
 
-    matrix_data_t *RESTRICT const A = a->data;
+    matrix_data_t *const A = a->data;
     matrix_data_t *const B = b->data;
     matrix_data_t *C = c->data;
 

--- a/src/kalman.c
+++ b/src/kalman.c
@@ -149,7 +149,7 @@ void kalman_predict_Q(register kalman_t *const kf)
     matrix_mult_transb(P_temp, A, P);               // P = temp*A'
 
     // P = P + B*Q*B'
-    if (kf->B.rows > 0)
+    if (kf->B.cols > 0)
     {
         matrix_mult(B, &kf->Q, BQ_temp, aux);       // temp = B*Q
         matrix_multadd_transb(BQ_temp, B, P);       // P += temp*B'
@@ -185,7 +185,7 @@ void kalman_predict_Q_tuned(register kalman_t *const kf, matrix_data_t lambda)
     matrix_multscale_transb(P_temp, A, lambda, P);   // P = temp*A' * 1/(lambda^2)
 
     // P = P + B*Q*B'
-    if (kf->B.rows > 0)
+    if (kf->B.cols > 0)
     {
         matrix_mult(B, &kf->Q, BQ_temp, aux);       // temp = B*Q
         matrix_multadd_transb(BQ_temp, B, P);        // P += temp*B'

--- a/src/kalman_unittests.c
+++ b/src/kalman_unittests.c
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2014-2024 Markus Mayer
+//
+// Part of kalman-clib - https://github.com/sunsided/kalman-clib
+// Licensed under the MIT License. See LICENSE.md in the project root for details.
+
+#include <assert.h>
+#include <stdint.h>
+
+#define EXTERN_INLINE_MATRIX static INLINE
+#define EXTERN_INLINE_KALMAN static INLINE
+
+#include "kalman.h"
+#include "kalman_unittests.h"
+
+/*!
+* \brief Regression test for the covariance prediction with zero inputs.
+*
+* Reproduces the layout the filter factory produces for a filter without inputs
+* (see kalman_factory_filter.h): B is (num_states x 0) and Q is (0 x 0), both with
+* a NULL data buffer. The covariance update must reduce to P = A*P*A' and must NOT
+* feed the empty/NULL B and Q matrices into the matrix routines.
+*
+* This pins finding #1: the input guard used to test B.rows (== num_states, always
+* > 0) instead of B.cols (== num_inputs). With the buggy guard, kalman_predict_Q
+* calls matrix_mult / matrix_multadd_transb with B/Q whose data == NULL, tripping
+* the data-pointer assertions in matrix.c. With the fix the B*Q*B' branch is skipped.
+*/
+static void test_predict_zero_inputs(void)
+{
+    enum { N = 2 };
+
+    matrix_data_t A[N * N] = { 1, 2,
+                               0, 1 };
+    matrix_data_t P[N * N] = { 1, 0,
+                               0, 1 };
+
+    matrix_data_t aux[N] = { 0, 0 };
+    matrix_data_t predicted_x[N] = { 0, 0 };
+    matrix_data_t temp_P[N * N] = { 0, 0, 0, 0 };
+    // temp_BQ is (N x 0) == zero elements; mirror the factory by giving it a real
+    // (non-NULL) backing buffer regardless.
+    matrix_data_t temp_BQ[1] = { 0 };
+
+    kalman_t kf;
+    kalman_filter_initialize(&kf, N, /*num_inputs*/ 0,
+                             A, /*x*/ (matrix_data_t *)0,
+                             /*B*/ (matrix_data_t *)0, /*u*/ (matrix_data_t *)0,
+                             P, /*Q*/ (matrix_data_t *)0,
+                             aux, predicted_x, temp_P, temp_BQ);
+
+    kalman_predict_Q(&kf);
+
+    // Expected P' = A*P*A' (no B*Q*B' contribution). With P = I this is A*A':
+    //   [[1*1+2*2, 1*0+2*1], [0*1+1*2, 0*0+1*1]] = [[5, 2], [2, 1]]
+    assert(P[0] == (matrix_data_t)5);
+    assert(P[1] == (matrix_data_t)2);
+    assert(P[2] == (matrix_data_t)2);
+    assert(P[3] == (matrix_data_t)1);
+}
+
+/*!
+* \brief Regression test for the covariance prediction with inputs.
+*
+* Ensures the B*Q*B' term is still applied when the filter has inputs, guarding
+* against a regression that disables or mis-scales the input contribution.
+*/
+static void test_predict_with_inputs(void)
+{
+    enum { N = 1, M = 1 };
+
+    matrix_data_t A[N * N] = { 1 };
+    matrix_data_t P[N * N] = { 3 }; // p = 3
+    matrix_data_t B[N * M] = { 2 }; // b = 2
+    matrix_data_t Q[M * M] = { 5 }; // q = 5
+
+    matrix_data_t aux[N] = { 0 };
+    matrix_data_t predicted_x[N] = { 0 };
+    matrix_data_t temp_P[N * N] = { 0 };
+    matrix_data_t temp_BQ[N * M] = { 0 };
+
+    kalman_t kf;
+    kalman_filter_initialize(&kf, N, M,
+                             A, /*x*/ (matrix_data_t *)0,
+                             B, /*u*/ (matrix_data_t *)0,
+                             P, Q,
+                             aux, predicted_x, temp_P, temp_BQ);
+
+    kalman_predict_Q(&kf);
+
+    // Expected P' = A*P*A' + B*Q*B' = 1*3*1 + 2*5*2 = 3 + 20 = 23
+    assert(P[0] == (matrix_data_t)23);
+}
+
+/*!
+* \brief Regression test for in-place matrix subtraction with output aliasing input a.
+*
+* Mirrors kalman_correct's `matrix_sub(P, temp_KHP, P)` (P = P - K*H*P). Pins finding
+* #2: matrix_sub must produce correct results when c aliases a, even after the input
+* loses its (incorrect) `restrict` qualifier. Build with optimization for this to bite.
+*/
+static void test_matrix_sub_aliased(void)
+{
+    matrix_data_t pd[2 * 2] = { 10, 20, 30, 40 };
+    matrix_data_t kd[2 * 2] = { 1, 2, 3, 4 };
+
+    matrix_t p, k;
+    matrix_init(&p, 2, 2, pd);
+    matrix_init(&k, 2, 2, kd);
+
+    // output (c) aliases input (a), as in kalman_correct
+    matrix_sub(&p, &k, &p);
+
+    assert(pd[0] == (matrix_data_t)9);
+    assert(pd[1] == (matrix_data_t)18);
+    assert(pd[2] == (matrix_data_t)27);
+    assert(pd[3] == (matrix_data_t)36);
+}
+
+/*!
+* \brief Regression tests for the Kalman filter core.
+*/
+void kalman_unittests()
+{
+    test_predict_zero_inputs();
+    test_predict_with_inputs();
+    test_matrix_sub_aliased();
+}

--- a/src/kalman_unittests.c
+++ b/src/kalman_unittests.c
@@ -5,6 +5,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for details.
 
 #include <assert.h>
+#include <math.h>
 #include <stdint.h>
 
 #define EXTERN_INLINE_MATRIX static INLINE
@@ -12,6 +13,21 @@
 
 #include "kalman.h"
 #include "kalman_unittests.h"
+
+/*!
+* \brief Asserts that two matrix values are equal within a small tolerance.
+*
+* The expected values in these tests are exact integers reached by multiply-add
+* chains, so they are representable in the default float matrix_data_t and would
+* even pass an exact `==`. We compare with a tolerance instead so the tests stay
+* correct if matrix_data_t becomes a less exact type, or if a translation unit is
+* built with -ffast-math (which may reassociate the floating-point operations).
+*/
+static void expect_close(matrix_data_t actual, matrix_data_t expected)
+{
+    const double tol = 1e-3;
+    assert(fabs((double)actual - (double)expected) <= tol);
+}
 
 /*!
 * \brief Regression test for the covariance prediction with zero inputs.
@@ -53,10 +69,10 @@ static void test_predict_zero_inputs(void)
 
     // Expected P' = A*P*A' (no B*Q*B' contribution). With P = I this is A*A':
     //   [[1*1+2*2, 1*0+2*1], [0*1+1*2, 0*0+1*1]] = [[5, 2], [2, 1]]
-    assert(P[0] == (matrix_data_t)5);
-    assert(P[1] == (matrix_data_t)2);
-    assert(P[2] == (matrix_data_t)2);
-    assert(P[3] == (matrix_data_t)1);
+    expect_close(P[0], 5);
+    expect_close(P[1], 2);
+    expect_close(P[2], 2);
+    expect_close(P[3], 1);
 }
 
 /*!
@@ -89,7 +105,7 @@ static void test_predict_with_inputs(void)
     kalman_predict_Q(&kf);
 
     // Expected P' = A*P*A' + B*Q*B' = 1*3*1 + 2*5*2 = 3 + 20 = 23
-    assert(P[0] == (matrix_data_t)23);
+    expect_close(P[0], 23);
 }
 
 /*!
@@ -111,10 +127,10 @@ static void test_matrix_sub_aliased(void)
     // output (c) aliases input (a), as in kalman_correct
     matrix_sub(&p, &k, &p);
 
-    assert(pd[0] == (matrix_data_t)9);
-    assert(pd[1] == (matrix_data_t)18);
-    assert(pd[2] == (matrix_data_t)27);
-    assert(pd[3] == (matrix_data_t)36);
+    expect_close(pd[0], 9);
+    expect_close(pd[1], 18);
+    expect_close(pd[2], 27);
+    expect_close(pd[3], 36);
 }
 
 /*!

--- a/src/kalman_unittests.h
+++ b/src/kalman_unittests.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: Copyright (c) 2014-2024 Markus Mayer
+//
+// Part of kalman-clib - https://github.com/sunsided/kalman-clib
+// Licensed under the MIT License. See LICENSE.md in the project root for details.
+
+#ifndef KALMAN_UNITTESTS_H_
+#define KALMAN_UNITTESTS_H_
+
+/*!
+* \brief Regression tests for the Kalman filter core (kalman.c).
+*/
+void kalman_unittests();
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -5,6 +5,7 @@
 // Licensed under the MIT License. See LICENSE.md in the project root for details.
 
 #include "matrix_unittests.h"
+#include "kalman_unittests.h"
 #include "kalman_example_gravity.h"
 
 /**
@@ -13,6 +14,7 @@
 int main(void)
 {
     matrix_unittests();
+    kalman_unittests();
 
     kalman_gravity_demo();
     kalman_gravity_demo_lambda();

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -84,6 +84,16 @@ void matrix_invert_lower(const matrix_t *RESTRICT const lower, matrix_t *RESTRIC
 void matrix_mult(const matrix_t *const a, const matrix_t *const b, const matrix_t *RESTRICT c, matrix_data_t *const baux)
 {
     register int_fast16_t i, j, k;
+
+    // assert pointer validity (before any dereference)
+    assert(a != (matrix_t*)0);
+    assert(b != (matrix_t*)0);
+    assert(c != (matrix_t*)0);
+    assert(baux != (matrix_data_t*)0);
+    assert(a->data != (matrix_data_t*)0);
+    assert(b->data != (matrix_data_t*)0);
+    assert(c->data != (matrix_data_t*)0);
+
     const uint_fast8_t bcols = b->cols;
     const uint_fast8_t ccols = c->cols;
     const uint_fast8_t brows = b->rows;
@@ -91,12 +101,6 @@ void matrix_mult(const matrix_t *const a, const matrix_t *const b, const matrix_
 
     matrix_data_t *RESTRICT const adata = a->data;
     matrix_data_t *RESTRICT const cdata = c->data;
-
-    // assert pointer validity
-    assert(a != (matrix_t*)0);
-    assert(b != (matrix_t*)0);
-    assert(c != (matrix_t*)0);
-    assert(baux != (matrix_data_t*)0);
 
     // test dimensions of a and b
     assert(a->cols == b->rows);
@@ -180,6 +184,15 @@ void matrix_mult_transb(const matrix_t *const a, const matrix_t *const b, const 
 void matrix_multadd_transb(const matrix_t *const a, const matrix_t *const b, const matrix_t *RESTRICT c)
 {
     register uint_fast16_t xA, xB, indexA, indexB, end;
+
+    // assert pointer validity (before any dereference)
+    assert(a != (matrix_t*)0);
+    assert(b != (matrix_t*)0);
+    assert(c != (matrix_t*)0);
+    assert(a->data != (matrix_data_t*)0);
+    assert(b->data != (matrix_data_t*)0);
+    assert(c->data != (matrix_data_t*)0);
+
     const uint_fast8_t bcols = b->cols;
     const uint_fast8_t brows = b->rows;
     const uint_fast8_t arows = a->rows;

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -140,6 +140,15 @@ void matrix_mult(const matrix_t *const a, const matrix_t *const b, const matrix_
 void matrix_mult_transb(const matrix_t *const a, const matrix_t *const b, const matrix_t *RESTRICT c)
 {
     register uint_fast16_t xA, xB, indexA, indexB, end;
+
+    // assert pointer validity (before any dereference)
+    assert(a != (matrix_t*)0);
+    assert(b != (matrix_t*)0);
+    assert(c != (matrix_t*)0);
+    assert(a->data != (matrix_data_t*)0);
+    assert(b->data != (matrix_data_t*)0);
+    assert(c->data != (matrix_data_t*)0);
+
     const uint_fast8_t bcols = b->cols;
     const uint_fast8_t brows = b->rows;
     const uint_fast8_t arows = a->rows;
@@ -237,6 +246,15 @@ void matrix_multadd_transb(const matrix_t *const a, const matrix_t *const b, con
 void matrix_multscale_transb(const matrix_t *const a, const matrix_t *const b, register const matrix_data_t scale, const matrix_t *RESTRICT c)
 {
     register uint_fast16_t xA, xB, indexA, indexB, end;
+
+    // assert pointer validity (before any dereference)
+    assert(a != (matrix_t*)0);
+    assert(b != (matrix_t*)0);
+    assert(c != (matrix_t*)0);
+    assert(a->data != (matrix_data_t*)0);
+    assert(b->data != (matrix_data_t*)0);
+    assert(c->data != (matrix_data_t*)0);
+
     const uint_fast8_t bcols = b->cols;
     const uint_fast8_t brows = b->rows;
     const uint_fast8_t arows = a->rows;

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -109,8 +109,10 @@ void matrix_mult(const matrix_t *const a, const matrix_t *const b, const matrix_
     assert(a->rows == c->rows);
     assert(b->cols == c->cols);
 
-    //for (j = 0; j < bcols; ++j)
-    for (j = bcols-1; j >= 0; --j)
+    // Iterate columns in reverse. The `j-- > 0` form is well-defined for bcols == 0;
+    // `j = bcols - 1` could underflow to a large value if uint_fast8_t promotes to an
+    // unsigned type, since j is a (wider) signed integer.
+    for (j = bcols; j-- > 0; )
     {
         // create a copy of the column in B to avoid cache issues
         matrix_get_column_copy(b, j, baux);


### PR DESCRIPTION
## What

`kalman_predict_Q` / `kalman_predict_Q_tuned` gated the `B*Q*B'` covariance term with `if (kf->B.rows > 0)`. `B` is `num_states x num_inputs`, so `B.rows == num_states` is **always > 0** — the guard never fired. The intended condition is "the filter has inputs", i.e. `B.cols == num_inputs`.

For a zero-input filter the factory leaves `B`/`Q` as NULL-data matrices; the branch ran the multiplies anyway and only dodged a NULL dereference because the inner loops were zero-trip. Correct by accident and brittle. This PR fixes both guards to test `B.cols`, hardens the matrix routines so the bug can't hide again, and adds regression tests.

## Findings addressed
1. **Input guard (the bug)** — `kalman.c`: `B.rows > 0` → `B.cols > 0` (both predict functions).
2. **`restrict` aliasing** — `matrix.h`: `matrix_sub`'s input `A` was `restrict`, but `kalman_correct` calls `matrix_sub(P, KHP, P)` (output aliases input). Dropped the qualifier, documented the alias.
3. **Dead asserts** — `matrix.c`: `matrix_mult` dereferenced `a->data`/`c->data` before the null checks. Moved asserts ahead of any deref and assert the data buffers; added the same to `matrix_multadd_transb`.
4. **Stale doc** — `kalman.h`: removed a `lambda` param line from `kalman_predict`'s comment.

(Finding #5, the `INLINE` macro being a no-op, is a judgment call and intentionally left out of scope.)

## Why the test needed a trick
With zero inputs the buggy branch is a **numeric no-op** (B/Q are zero-column), so a "wrong number" test can't see it. The only real difference is whether empty/NULL B,Q get fed to the matrix routines — so the hardened data-pointer asserts (finding #3) are the mechanism that turns the latent bug into a hard failure.

## Tests (`src/kalman_unittests.c`, run from `main` and via `ctest`)
- `test_predict_zero_inputs` — pins #1: zero-input filter, asserts `P == A*P*A'` and that NULL B,Q never reach the matrix routines.
- `test_predict_with_inputs` — asserts `P == p + b*b*q`, keeps the input path alive.
- `test_matrix_sub_aliased` — pins #2: in-place `matrix_sub(P, KHP, P)`.

## CI
`ctest` gate in Debug, plus an optimized pass (`Debug + -O2`, so `NDEBUG` stays undefined and asserts remain live) to exercise the `matrix_sub` aliasing path under optimization.

## Verification
- With the hardened asserts but the **old** guard, `./example` aborts: `matrix.c: matrix_mult: Assertion 'a->data != ...' failed`.
- After the guard fix: `ctest` green in both Debug and optimized builds; gravity example still converges (`9 < g < 10`).

## Review order
`src/kalman.c` (the fix) → `src/matrix.c` (assert hardening) → `src/kalman_unittests.c` (tests) → `include/matrix.h` / `include/kalman.h` → `CMakeLists.txt` / `.github/workflows/ci.yml`.